### PR TITLE
Fixes invalid positioning and rotation when reparenting nodes

### DIFF
--- a/src/at/vintagestory/modelcreator/gui/right/TreeTransferHandler.java
+++ b/src/at/vintagestory/modelcreator/gui/right/TreeTransferHandler.java
@@ -217,6 +217,8 @@ class TreeTransferHandler extends TransferHandler {
   
     private void applyReparentTransform(Element ownElem, List<Element> oldParentPath, List<Element> newParentPath)
 	{
+        ModelCreator.ignoreValueUpdates = true;
+
         float[] matrix = Mat4f.Create();
         
         for (int j = 0; j < newParentPath.size(); j++) {
@@ -232,25 +234,28 @@ class TreeTransferHandler extends TransferHandler {
 
         
         float[] originpos = Mat4f.MulWithVec4(matrix, new float[] { (float)ownElem.getOriginX(), (float)ownElem.getOriginY(), (float)ownElem.getOriginZ(), 1 });
-        float[] startpos = Mat4f.MulWithVec4(matrix, new float[] { (float)ownElem.getStartX(), (float)ownElem.getStartY(), (float)ownElem.getStartZ(), 1 });
         
-        ownElem.ApplyTransform(matrix);        
+        ownElem.ApplyTransform(matrix);
         double[] angles = QUtil.MatrixToEuler(matrix);
-        
-        
-        
-        ModelCreator.ignoreValueUpdates = true;
+
+        ownElem.setOriginX(originpos[0]);
+        ownElem.setOriginY(originpos[1]);
+        ownElem.setOriginZ(originpos[2]);
+
+        ownElem.setRotationX(-angles[0] * GameMath.RAD2DEG);
+        ownElem.setRotationY(-angles[1] * GameMath.RAD2DEG);
+        ownElem.setRotationZ(-angles[2] * GameMath.RAD2DEG);
+
+        Mat4f.Invert(matrix, matrix);
+        ownElem.ApplyTransform(matrix);
+        Mat4f.Invert(matrix, matrix);
+
+        float[] startpos = Mat4f.MulWithVec4(matrix, new float[] { (float)ownElem.getStartX(), (float)ownElem.getStartY(), (float)ownElem.getStartZ(), 1 });
+
     	ownElem.setStartX(startpos[0]);
     	ownElem.setStartY(startpos[1]);
     	ownElem.setStartZ(startpos[2]);
 
-    	ownElem.setOriginX(originpos[0]);
-    	ownElem.setOriginY(originpos[1]);
-    	ownElem.setOriginZ(originpos[2]);
-    	
-    	ownElem.setRotationX(-angles[0] * GameMath.RAD2DEG);
-    	ownElem.setRotationY(-angles[1] * GameMath.RAD2DEG);
-    	ownElem.setRotationZ(-angles[2] * GameMath.RAD2DEG);
     	ModelCreator.ignoreValueUpdates = false;
 	}
     

--- a/src/at/vintagestory/modelcreator/util/QUtil.java
+++ b/src/at/vintagestory/modelcreator/util/QUtil.java
@@ -5,6 +5,9 @@ import org.lwjgl.util.vector.Quaternion;
 
 public class QUtil
 {
+    /**
+     * Converts yaw, pitch, roll to a quaternion
+     */
 	public static Quaternion ToQuaternion(double yaw, double pitch, double roll) // yaw (Z), pitch (Y), roll (X)
 	{
 	    // Abbreviations for the various angular functions
@@ -25,10 +28,43 @@ public class QUtil
 	    
 	    return q;
 	}
-	
-	
 
+    /**
+     * Converts intrinsic x/y/z euler angles as used by the game to a hamilton quaternion.
+     */
+	public static Quaternion IntrinsicXYZToQuaternion(double alpha, double beta, double gamma)
+    {
+        double ca = Math.cos(alpha * 0.5);
+        double sa = Math.sin(alpha * 0.5);
+        double cb = Math.cos(beta * 0.5);
+        double sb = Math.sin(beta * 0.5);
+        double cy = Math.cos(gamma * 0.5);
+        double sy = Math.sin(gamma * 0.5);
 
+        double w = ca * cb * cy + sa * sb * sy;
+        double x = sa * cb * cy - ca * sb * sy;
+        double y = ca * sb * cy + sa * cb * sy;
+        double z = ca * cb * sy - sa * sb * cy;
+
+        return new Quaternion((float)x, (float)y, (float)z, (float)w);
+    }
+
+    /**
+     * Converts to x/y/z rotation euler output, as used by the game
+     */
+    public static double[] ToIntrinsicXYZEuler(Quaternion q)
+    {
+        double[] angles = ToEulerAngles(q);
+        double temp = angles[0];
+        angles[0] = angles[2];
+        angles[2] = temp;
+
+        return angles;
+    }
+
+    /**
+     * Converts to yaw, pitch, roll euler angles.
+     */
     public static double[] ToEulerAngles(Quaternion q)
     {
     	double[] angles = new double[3];
@@ -76,6 +112,6 @@ public class QUtil
         Quaternion.setFromMatrix(mat, q);
 
         
-        return QUtil.ToEulerAngles(q);
+        return QUtil.ToIntrinsicXYZEuler(q);
     }
 }


### PR DESCRIPTION
Currently, when reparenting cubes in the element tree, their rotation and position is not properly updated. This causes them to move and rotate in view, while the desired behavior is that the cube stays at exactly the same place where it was before.

This commit fixes two bugs, therefore allowing moved nodes to stay at exactly the same position as they were.